### PR TITLE
feat: implement create space with theme

### DIFF
--- a/src/components/CreateContent/CreateContent.tsx
+++ b/src/components/CreateContent/CreateContent.tsx
@@ -1,6 +1,9 @@
+import { AxiosResponse } from 'axios'
 import { ReactNode, RefObject, useCallback, useRef, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
+import { useNavigate } from 'react-router-dom'
 
+import { axiosPrivate } from '@/api/axios'
 import {
   StepperContent,
   StepperContentAction,
@@ -8,8 +11,9 @@ import {
   StepperController,
   StepperRef,
 } from '@/components/Commons/Stepper'
+import { Space, SpaceTheme } from '@/models/Space'
 
-import { SelectTheme, SpaceInfo } from '.'
+import { CreateSpaceTheme, SelectTheme, SpaceInfo } from '.'
 
 export type CreateContentProps = {
   stepperRef: RefObject<StepperRef>
@@ -20,10 +24,18 @@ export type CanNextCreateContentProps = {
   onCanNext?: (canNext: boolean) => void
 }
 
+type CreateSpaceSubmitType = {
+  name: string
+  password?: string
+  models?: []
+  theme: SpaceTheme
+}
+
 export const CreateContent = ({ stepperRef, onThemeChange }: CreateContentProps) => {
   const [canStepperNext, setStepperNext] = useState(false)
   const [content, setContent] = useState<ReactNode>(null)
   const methods = useForm({ mode: 'onChange' })
+  const navigate = useNavigate()
 
   const handleCanNext = useCallback((canNext: boolean) => setStepperNext(canNext), [])
 
@@ -36,6 +48,31 @@ export const CreateContent = ({ stepperRef, onThemeChange }: CreateContentProps)
     setContent(contentRef.current[step])
   }, [])
 
+  const handleSubmit = () => {
+    methods.handleSubmit(
+      (data) => {
+        console.log(data)
+        const theme = data.theme as CreateSpaceTheme
+        const isCustom = theme === 'custom'
+
+        axiosPrivate
+          .post<Space, AxiosResponse<Space>, CreateSpaceSubmitType>('/spaces', {
+            name: data.name,
+            password: data.password,
+            models: isCustom ? [] : undefined,
+            theme: isCustom ? false : theme,
+          })
+          .then((res) => {
+            console.log(res.data)
+            navigate(`/${res.data.code}`)
+          })
+      },
+      (errors) => {
+        console.log(errors)
+      },
+    )()
+  }
+
   return (
     <FormProvider {...methods}>
       <StepperContent>
@@ -45,7 +82,7 @@ export const CreateContent = ({ stepperRef, onThemeChange }: CreateContentProps)
             canNext={canStepperNext}
             stepperRef={stepperRef}
             onChange={handleChange}
-            onSubmit={methods.handleSubmit((data) => console.log(data))}
+            onSubmit={handleSubmit}
           />
         </StepperContentAction>
       </StepperContent>

--- a/src/components/CreateContent/SelectTheme/SelectTheme.tsx
+++ b/src/components/CreateContent/SelectTheme/SelectTheme.tsx
@@ -7,64 +7,66 @@ import { BasicButton } from '@/components/Button'
 import { Text } from '@/components/Commons'
 import { ButtonContent } from '@/components/Commons/Button'
 import { MultiToggle, MultiToggleProps, MultiToggleRef, ToggleLabel } from '@/components/Commons/MultiToggle'
+import { CustomableSpaceTheme } from '@/models/Space'
 
 import { CanNextCreateContentProps, CreateForm, CreateFormHeader } from '..'
 import { ThemeImage, ThemeImageCard } from './ThemeImageCard'
 
-type SpaceThemeType = 'office' | 'conference' | 'event' | 'workshop' | 'custom'
+export type CreateSpaceTheme = CustomableSpaceTheme
 
-type SpaceTheme = {
-  [key in SpaceThemeType]: ReactNode
+type CreateSpaceThemes = {
+  [key in CreateSpaceTheme]: ReactNode
 }
 
-const themes: SpaceTheme = {
-  office: (
+const themes: CreateSpaceThemes = {
+  home: (
     <ThemeImageCard
-      key={'office-image'}
-      name="Office"
+      key={'home-image'}
+      name="Home"
       src="https://31e58c129a.cbaul-cdnwnd.com/b10995abef9b7109e0c8dd76841104e4/200000058-2a47f2a481/0042.jpg?ph=31e58c129a"
     ></ThemeImageCard>
   ),
-  conference: (
+  forest: (
     <ThemeImageCard
-      key={'conference-image'}
-      name="Conference"
+      key={'forest-image'}
+      name="Forest"
       src="https://w0.peakpx.com/wallpaper/172/710/HD-wallpaper-anime-girl-purple-eyes-cyberpunk-anime-girl-anime-cyberpunk-artist-artwork-digital-art.jpg"
     ></ThemeImageCard>
   ),
-  event: (
-    <ThemeImageCard
-      key={'event-image'}
-      name="Event"
-      src="https://wallpaperaccess.com/full/1761194.jpg"
-    ></ThemeImageCard>
+  city: (
+    <ThemeImageCard key={'city-image'} name="City" src="https://wallpaperaccess.com/full/1761194.jpg"></ThemeImageCard>
   ),
-  workshop: (
+  kidsplayground: (
     <ThemeImageCard
-      key={'workshop-image'}
-      name="Workshop"
+      key={'kidsplayground-image'}
+      name="Kids Playground"
       src="https://i.pinimg.com/originals/fd/09/ef/fd09ef6514db7fb0798f1f0c362bcab0.jpg"
     ></ThemeImageCard>
   ),
   custom: <ThemeImageCard key={'custom-image'} name="Custom" src={CustomImage}></ThemeImageCard>,
 }
 
-const themeOptions = [
+type ThemeOptionType = {
+  value: CreateSpaceTheme
+  display: CreateSpaceThemes[keyof CreateSpaceThemes]
+}
+
+const themeOptions: ThemeOptionType[] = [
   {
-    value: 'office',
-    display: themes['office'],
+    value: 'home',
+    display: themes['home'],
   },
   {
-    value: 'conference',
-    display: themes['conference'],
+    value: 'forest',
+    display: themes['forest'],
   },
   {
-    value: 'event',
-    display: themes['event'],
+    value: 'city',
+    display: themes['city'],
   },
   {
-    value: 'workshop',
-    display: themes['workshop'],
+    value: 'kidsplayground',
+    display: themes['kidsplayground'],
   },
 ]
 
@@ -87,7 +89,7 @@ export const SelectTheme = ({ onThemeSelected, onCanNext }: SelectThemeProps) =>
     (value: any) => {
       setValue('theme', value)
       onCanNext?.(true)
-      onThemeSelected?.(themes[value as SpaceThemeType])
+      onThemeSelected?.(themes[value as CreateSpaceTheme])
     },
     [setValue, onCanNext, onThemeSelected],
   )

--- a/src/components/CreateContent/SpaceInfo/SpaceInfo.tsx
+++ b/src/components/CreateContent/SpaceInfo/SpaceInfo.tsx
@@ -24,17 +24,18 @@ export const SpaceInfo = ({ onCanNext = () => {} }: SpaceInfoProps) => {
 
   const { register, getValues, setValue, formState, getFieldState, setFocus } = useFormContext()
 
-  const nameField = register('space-name', {
+  const nameField = register('name', {
     required: true,
     validate: { whitespace: isOnlyWhitespace },
+    minLength: 2,
   })
-  const passwordField = register('space-password', {
+  const passwordField = register('password', {
     required: true,
     disabled: !enablePassword,
     validate: { whitespace: isOnlyWhitespace },
   })
-  const nameState = getFieldState('space-name', formState)
-  const passwordState = getFieldState('space-password', formState)
+  const nameState = getFieldState('name', formState)
+  const passwordState = getFieldState('password', formState)
 
   useEffect(() => {
     onCanNext(
@@ -45,11 +46,11 @@ export const SpaceInfo = ({ onCanNext = () => {} }: SpaceInfoProps) => {
   register('max-member', { value: 10 })
 
   useEffect(() => {
-    setFocus('space-name')
+    setFocus('name')
   }, [setFocus])
 
   useEffect(() => {
-    if (enablePassword) setFocus('space-password')
+    if (enablePassword) setFocus('password')
   }, [enablePassword, setFocus])
 
   return (
@@ -61,16 +62,16 @@ export const SpaceInfo = ({ onCanNext = () => {} }: SpaceInfoProps) => {
       </CreateFormHeader>
 
       <CreateField>
-        <CreateLabel htmlFor="space-name">
+        <CreateLabel htmlFor="name">
           <SpaceInfoText size="medium" weight="normal">
             SpaceName
           </SpaceInfoText>
         </CreateLabel>
-        <CreateInput id="space-name" {...nameField} placeholder="Space Name" type="text" />
+        <CreateInput id="name" {...nameField} placeholder="Space Name" type="text" />
       </CreateField>
 
       <CreateField>
-        <PasswordLabel htmlFor="space-password">
+        <PasswordLabel htmlFor="password">
           <SpaceInfoText size="medium" weight="normal">
             Password protect
           </SpaceInfoText>
@@ -87,7 +88,7 @@ export const SpaceInfo = ({ onCanNext = () => {} }: SpaceInfoProps) => {
         </PasswordLabel>
 
         <PasswordInputContainer disabled={enablePassword}>
-          <CreateInput id="space-password" {...passwordField} placeholder="Space Password" type="password" />
+          <CreateInput id="password" {...passwordField} placeholder="Space Password" type="password" />
         </PasswordInputContainer>
       </CreateField>
 

--- a/src/components/Dashboard/Libraries.tsx
+++ b/src/components/Dashboard/Libraries.tsx
@@ -3,7 +3,8 @@ import styled from 'styled-components'
 
 import { SpacePreviewCard } from '@/components/SpacePreviewCard'
 import { SubCategoryToggle } from '@/components/SubcategoryToggle'
-import { Space as SpaceType, useDashboardStore } from '@/stores'
+import { CustomableSpaceTheme, Space } from '@/models/Space'
+import { useDashboardStore } from '@/stores'
 
 const LibrariesContainer = styled.div`
   width: 100%;
@@ -25,37 +26,50 @@ const List = styled.div`
   margin: 8px 0;
 `
 
+type ToogleTheme = CustomableSpaceTheme | 'all'
+type ToogleThemeOptions = {
+  [key in ToogleTheme]: string
+}
+
 export const Libraries = () => {
   const [librarySpaces] = useDashboardStore((state) => [state.librarySpaces])
 
-  const [selectedCategory, setSelectedCategory] = useState<string>('all')
-  const [listLibrarySpaces, setListLibrarySpaces] = useState<SpaceType[]>([])
+  const [selectedTheme, setSelectedTheme] = useState<ToogleTheme>('all')
+  const [listLibrarySpaces, setListLibrarySpaces] = useState<Space[]>([])
 
   const handleChange = useCallback((data: any) => {
-    setSelectedCategory(data)
+    setSelectedTheme(data)
   }, [])
 
   useEffect(() => {
     const myArray = Array.from(librarySpaces.values())
 
-    if (selectedCategory === 'all') {
+    if (selectedTheme === 'all') {
       setListLibrarySpaces(myArray.flat())
     } else {
-      setListLibrarySpaces(librarySpaces.get(selectedCategory) || [])
+      setListLibrarySpaces(librarySpaces.get(selectedTheme) || [])
     }
-  }, [selectedCategory])
+  }, [selectedTheme, librarySpaces])
+
+  const themeOptions: ToogleThemeOptions = {
+    all: 'All',
+    city: 'City',
+    forest: 'Forest',
+    home: 'Home',
+    kidsplayground: 'Kids Playground',
+    custom: 'Custom',
+  }
 
   return (
     <LibrariesContainer>
       <Wrapper>
         <SubCategoryToggle
           handleSelectedChange={handleChange}
-          options={[
-            { value: 'all', display: 'All' },
-            { value: 'offices', display: 'Offices' },
-            { value: 'families', display: 'Families' },
-          ]}
-          selected={selectedCategory}
+          options={Object.keys(themeOptions).map((key) => ({
+            value: key,
+            display: themeOptions[key as ToogleTheme],
+          }))}
+          selected={selectedTheme}
         ></SubCategoryToggle>
         <List>
           {listLibrarySpaces.map((item) => (

--- a/src/components/Dashboard/hooks/useDashboard.ts
+++ b/src/components/Dashboard/hooks/useDashboard.ts
@@ -1,7 +1,7 @@
 import { orderBy, take } from 'lodash-es'
 import * as timeago from 'timeago.js'
 
-import { Space } from '@/stores'
+import { CustomableSpaceTheme, Space } from '@/models/Space'
 
 const useDashboard = () => {
   const calculateTimeAgo = (timestamp: number) => {
@@ -16,26 +16,34 @@ const useDashboard = () => {
     return recentSpaces
   }
 
-  const convertArrayToMap = (array: Space[]) => {
-    const librarySpaces = new Map<string, Space[]>()
+  const convertSpacesToLibrarySpaces = (spaces: Space[]): Map<CustomableSpaceTheme, Space[]> => {
+    const librarySpaces = new Map<CustomableSpaceTheme, Space[]>()
 
-    array.forEach((space) => {
-      if (librarySpaces.has(space.category)) {
-        const spaces = librarySpaces.get(space.category)
+    const addSpaces = (theme: CustomableSpaceTheme, space: Space) => {
+      if (librarySpaces.has(theme)) {
+        const spaces = librarySpaces.get(theme)
 
         if (spaces) {
           spaces.push(space)
-          librarySpaces.set(space.category, spaces)
+          // librarySpaces.set(theme, spaces)
         }
       } else {
-        librarySpaces.set(space.category, [space])
+        librarySpaces.set(theme, [space])
+      }
+    }
+
+    spaces.forEach((space) => {
+      if (space.theme) {
+        addSpaces(space.theme, space)
+      } else {
+        addSpaces('custom', space)
       }
     })
 
     return librarySpaces
   }
 
-  return { calculateTimeAgo, convertArrayToMap, sortRecentSpace }
+  return { calculateTimeAgo, convertSpacesToLibrarySpaces, sortRecentSpace }
 }
 
 export { useDashboard }

--- a/src/components/SpaceTheme/ThemeScene.tsx
+++ b/src/components/SpaceTheme/ThemeScene.tsx
@@ -2,12 +2,13 @@
 import { Canvas } from '@react-three/fiber'
 import { Debug, Physics, RigidBody } from '@react-three/rapier'
 import { Perf } from 'r3f-perf'
-import { Suspense } from 'react'
+import { ReactNode, Suspense } from 'react'
 
 import { Hint } from '@/components/Hint'
 import { MainMember } from '@/components/Member'
 import { City, Forest, Home, KidsPlayground } from '@/components/SpaceTheme'
 import { Container } from '@/layouts/common'
+import { BuiltInTheme } from '@/models/Space'
 
 import { MemberVideoLayout } from '../VirtualSpace/MemberVideoLayout'
 import { OtherMember } from '../VirtualSpace/OtherMember'
@@ -15,7 +16,18 @@ import { OtherMember } from '../VirtualSpace/OtherMember'
 // import { MemberVideoLayout } from '../MemberVideoLayout'
 // import { OtherMember } from '../OtherMember'
 
-export const ThemeScene = () => {
+type ThemeElements = {
+  [key in BuiltInTheme]: ReactNode
+}
+
+const themes: ThemeElements = {
+  home: <Home />,
+  city: <City />,
+  forest: <Forest />,
+  kidsplayground: <KidsPlayground />,
+}
+
+export const ThemeScene = ({ theme }: { theme: BuiltInTheme }) => {
   return (
     <Container>
       <MemberVideoLayout />
@@ -25,8 +37,7 @@ export const ThemeScene = () => {
 
           <Physics gravity={[0, -9.82, 0]}>
             <Debug />
-            {/* <Home /> */}
-            <Forest />
+            {themes[theme]}
             <RigidBody position={[0, -2, 0]} rotation={[-Math.PI / 2, 0, 0]} type="fixed">
               <mesh castShadow receiveShadow>
                 <planeGeometry args={[1000, 1000]} />

--- a/src/components/VirtualSpace/Scene/Scene.tsx
+++ b/src/components/VirtualSpace/Scene/Scene.tsx
@@ -56,8 +56,8 @@ export const Scene = () => {
   return (
     <Container>
       <MemberVideoLayout />
-      <Canvas dpr={[0.25, 0.25]}>
-        <Perf />
+      <Canvas dpr={[1, 1]}>
+        {/* <Perf /> */}
         <Suspense fallback={null}>
           <Environment preset="city" />
           <ambientLight intensity={0.7} />

--- a/src/components/VirtualSpace/VirtualSpaceLoading.tsx
+++ b/src/components/VirtualSpace/VirtualSpaceLoading.tsx
@@ -10,9 +10,9 @@ import { useParams } from 'react-router-dom'
 import axiosConfigured from '@/api/axios'
 import { useAuth, useAxiosPrivate } from '@/hooks'
 import { generateHMSConfig } from '@/libs/utils'
+import { Space } from '@/models/Space'
 import {
   CategorySelectedItemId,
-  Space,
   useEditCharacterStore,
   useMemberStore,
   useNetworkStore,
@@ -43,7 +43,7 @@ export const VirtualSpaceLoading = (props: VirtualSpaceLoadingProps) => {
   const [password, setPassword] = useState('')
   const { auth } = useAuth()
 
-  const [setSpaceName] = useVirtualSpaceStore((state) => [state.setSpaceName])
+  const [setSpaceName, setSpaceTheme] = useVirtualSpaceStore((state) => [state.setSpaceName, state.setSpaceTheme])
   const [prepareState, setPrepareState] = useState<PrepareState>('')
 
   const [setRoomInstance] = useNetworkStore((state) => [state.setRoomInstance])
@@ -102,6 +102,7 @@ export const VirtualSpaceLoading = (props: VirtualSpaceLoadingProps) => {
           const password = space.password
 
           setSpaceName(space.name)
+          setSpaceTheme(space.theme)
           setRoomId(space.hmsRoomId)
           isHost.current = space.author === user?._id
 

--- a/src/hooks/useAxiosPrivate.ts
+++ b/src/hooks/useAxiosPrivate.ts
@@ -26,7 +26,7 @@ export const useAxiosPrivate = () => {
       async (error) => {
         const prevRequest = error?.config
 
-        if (error?.response?.status === 403 && !prevRequest?.sent) {
+        if (error?.response?.status === 401 && !prevRequest?.sent) {
           prevRequest.sent = true
           const newAccessToken = await refresh()
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -57,16 +57,18 @@ const Guard = () => {
           />
         </Route>
         <Route element={<PersistLogin />}>
-          <Route
-            element={
-              <Suspense fallback={<span>loading</span>}>
-                <MobileDetect>
-                  <Create />
-                </MobileDetect>
-              </Suspense>
-            }
-            path="/create"
-          />
+          <Route element={<RequireAuth allowedRoles={[ROLES.user]} />}>
+            <Route
+              element={
+                <Suspense fallback={<span>loading</span>}>
+                  <MobileDetect>
+                    <Create />
+                  </MobileDetect>
+                </Suspense>
+              }
+              path="/create"
+            />
+          </Route>
         </Route>
         <Route
           element={

--- a/src/models/Space.ts
+++ b/src/models/Space.ts
@@ -1,0 +1,23 @@
+// type Author = {
+//   _id: string
+//   username: string
+// }
+
+export type BuiltInTheme = 'home' | 'forest' | 'city' | 'kidsplayground'
+
+export type CustomableSpaceTheme = BuiltInTheme | 'custom'
+
+export type SpaceTheme = BuiltInTheme | false
+
+export type Space = {
+  _id: string
+  name: string
+  thumbnail: string
+  latestEdited: number
+  // author: Author
+  author: string
+  theme: SpaceTheme
+  code: string
+  password: string
+  hmsRoomId: string
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
 import styled from 'styled-components'
 
-import { exploreSpacesFromApi, HeaderDashboard, SpaceSection } from '@/components/Dashboard'
+import { exploreSpacesFromApi, HeaderDashboard, SpaceSection, useDashboard } from '@/components/Dashboard'
 import { NavigationPanel } from '@/components/Navigation'
 import { NotificationStack } from '@/components/Notification'
 import { useAxiosPrivate } from '@/hooks'
@@ -29,6 +29,7 @@ const Dashboard = () => {
     state.setExploreSpaces,
     state.setLibrarySpaces,
   ])
+  const { convertSpacesToLibrarySpaces } = useDashboard()
 
   const axiosPrivate = useAxiosPrivate()
 
@@ -42,7 +43,7 @@ const Dashboard = () => {
 
     Promise.all([mySpacesPromise, librarySpacesPromise]).then((res) => {
       setMySpaces(res[0].data)
-      setLibrarySpaces(res[1].data)
+      setLibrarySpaces(convertSpacesToLibrarySpaces(res[1].data))
     })
   }, [])
 

--- a/src/pages/VirtualSpace.tsx
+++ b/src/pages/VirtualSpace.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 
 import { CustomableContainer } from '@/components/Commons'
 import { MultitabDetect, MultiTabWarning } from '@/components/MultitabDetect'
+import { ThemeScene } from '@/components/SpaceTheme/ThemeScene'
 import { UtilitySection } from '@/components/UtilitySection'
 import {
   CustomCharacterPanel,
@@ -95,6 +96,7 @@ const LeftSideWrapper = styled.div`
 const VirtualSpace = () => {
   const customColor = useAppStore((state) => state.customColor)
   const [selectedUltility] = useVirtualSpaceStore((state) => [state.selectedUltility])
+  const [spaceTheme] = useVirtualSpaceStore((state) => [state.spaceTheme])
 
   useEffect(() => {
     document.title = 'Trysts | Summer Open Call'
@@ -107,7 +109,7 @@ const VirtualSpace = () => {
           <Container customColor={customColor}>
             <MultiplayerNetwork />
 
-            <Scene />
+            {spaceTheme ? <ThemeScene theme={spaceTheme} /> : <Scene />}
 
             <OverlayContainer>
               <IframeDialogProvider>

--- a/src/stores/dashboard.ts
+++ b/src/stores/dashboard.ts
@@ -1,23 +1,7 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 
-// type Author = {
-//   _id: string
-//   username: string
-// }
-
-export type Space = {
-  _id: string
-  name: string
-  thumbnail: string
-  latestEdited: number
-  // author: Author
-  author: string
-  category: string
-  code: string
-  password: string
-  hmsRoomId: string
-}
+import { CustomableSpaceTheme, Space } from '@/models/Space'
 
 // 1 for home, 2 for files, and 3 for libraries
 export type DashboardOption = 1 | 2 | 3
@@ -32,8 +16,8 @@ type DashboardState = {
   exploreSpaces: Space[]
   setExploreSpaces: (exploreSpaces: Space[]) => void
 
-  librarySpaces: Map<string, Space[]>
-  setLibrarySpaces: (librarySpacesFromApi: Space[]) => void
+  librarySpaces: Map<CustomableSpaceTheme, Space[]>
+  setLibrarySpaces: (librarySpacesFromApi: Map<CustomableSpaceTheme, Space[]>) => void
 }
 
 type NavigationState = {
@@ -59,21 +43,7 @@ export const useDashboardStore = create<DashboardState>()(
       setExploreSpaces: (exploreSpaces: Space[]) => set(() => ({ exploreSpaces })),
 
       librarySpaces: new Map(),
-      setLibrarySpaces: (librarySpacesFromApi: Space[]) => {
-        const librarySpaces = new Map<string, Space[]>()
-
-        librarySpacesFromApi.forEach((space) => {
-          if (librarySpaces.has(space.category)) {
-            const spaces = librarySpaces.get(space.category)
-
-            if (spaces) {
-              spaces.push(space)
-              librarySpaces.set(space.category, spaces)
-            }
-          } else {
-            librarySpaces.set(space.category, [space])
-          }
-        })
+      setLibrarySpaces: (librarySpaces: Map<CustomableSpaceTheme, Space[]>) => {
         set(() => ({ librarySpaces }))
       },
     }),

--- a/src/stores/virtualSpace.ts
+++ b/src/stores/virtualSpace.ts
@@ -2,6 +2,7 @@ import produce from 'immer'
 import { create } from 'zustand'
 
 import { CustomColor } from '@/components/Commons'
+import { SpaceTheme } from '@/models/Space'
 
 type UltilityType = 'chat' | 'member' | 'setting' | null
 export type VideoLayoutType = 'above-head' | 'slide'
@@ -38,6 +39,8 @@ type VirtualSpaceState = {
   setSpaceName: (spaceName: string) => void
   spaceModels: SpaceModelTemp[]
   setSpaceModels: (spaceModels: SpaceModelTemp[]) => void
+  spaceTheme: SpaceTheme
+  setSpaceTheme: (theme: SpaceTheme) => void
   selectedUltility: UltilityType
   setSelectedUltility: (selectedUltility: UltilityType) => void
   customColor: CustomColor
@@ -99,6 +102,9 @@ export const useVirtualSpaceStore = create<VirtualSpaceState>()((set) => ({
 
   spaceModels: [],
   setSpaceModels: (spaceModels) => set(() => ({ spaceModels })),
+
+  spaceTheme: false,
+  setSpaceTheme: (spaceTheme) => set(() => ({ spaceTheme })),
 
   selectedUltility: null,
   setSelectedUltility: (selectedUltility) => set(() => ({ selectedUltility })),


### PR DESCRIPTION
- Display a virtual space model based on its theme
- Add **RequireAuth** for **Create**
- Implement create space with API
- Update theme for **SelectTheme** in **Create**
- Update fields for **SpaceInfor** in **Create**
- Refactor **Libraries** for filtering by the new themes
- Refactor **useDashboard** for **Libraries** filtering
- Fix **axiosPrivate** refresh token interceptor
- Move ***Space*** types to the *models f*older